### PR TITLE
Additional nock.cleanAll in stop method

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -31,6 +31,7 @@ const createJWKSMock = (
       if (jwksUrlNock) {
         jwksUrlNock.persist(false)
         await request.get(url.resolve(jwksOrigin, jwksPath)) // Hack to remove the last nock.
+        nock.cleanAll()
       }
     },
     kid() {


### PR DESCRIPTION
We have a scenario where nock is intercepting another nock that is being used in our tests. The only option was to add additional `nock.cleanAll()` into `mock-jwks.stop()` in order to make sure there are no leftovers after the teardown.