### PR TITLE
chore: use correct secret for npm publish

### DIFF
--- a/.github/workflows/npm-publish-github-packages.yml
+++ b/.github/workflows/npm-publish-github-packages.yml
@@ -31,4 +31,4 @@ jobs:
       - run: yarn
       - run: yarn npm publish
         env:
-          YARN_NPM_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          YARN_NPM_AUTH_TOKEN: ${{secrets.YARN_NPM_AUTH_TOKEN}}


### PR DESCRIPTION
release-as: 1.0.5