### PR TITLE
Add tests for extended claims

### DIFF
--- a/example/custom_claims.test.js
+++ b/example/custom_claims.test.js
@@ -28,7 +28,7 @@ test("'Token should verify against the PKI'", async () => {
       'update:all',
       'delete:all',
     ],
-  } as Record<string, unknown>
+  }
 
   const token = signJwt(keyPair.privateKey, claims)
   const decoded = verify(

--- a/example/custom_claims.test.js
+++ b/example/custom_claims.test.js
@@ -1,0 +1,114 @@
+const createJWKSMock = require('../src/index').default
+const createApp = require('./api')
+const supertest = require('supertest')
+const { access } = require('fs')
+
+describe('Some tests for authentication for our api', () => {
+  let jwksMock, server, request
+  beforeEach(() => {
+    ({ jwksMock, server, request } = createContext())
+  })
+  afterEach(async () => await tearDown({ jwksMock, server }))
+
+  test('should not get access without correct token', async () => {
+    // We start intercepting queries (see below)
+    jwksMock.start()
+    const { status } = await request.get('/')
+    expect(status).toEqual(401)
+  })
+  test('should get access with mock token when jwksMock is running', async () => {
+    // Again we start intercepting queries
+    jwksMock.start()
+      
+    const claims = {
+      nickname: "jest.jester",
+      name: "jest@itest.com",
+      updated_at: "2022-10-09T11:36:37.582Z",
+      email: "jest@itest.com",
+      iss: "master",
+      sub: "auth0|633c191bd579670011607e98",
+      aud: "private",
+      iat: 1665315399,
+      exp: 5665351399,
+      sid: "lBZb4EUN7LpXu7Urp-lRQ3qnCzDVBf23",
+      nonce: "RzZtVlVTT1dqZ1lvWFpSYzFnbnB2RXZkdWcuNDJQRkREUH5KMUVJNWdMSA==",
+      roles: [
+        "admin",
+      ],
+      permissions: [
+        "create:all",
+        "read:all",
+        "write:all",
+        "update:all",
+        "delete:all",
+      ],
+    } 
+
+    const access_token = jwksMock.token(claims)
+
+    const { status } = await request
+      .get('/')
+      .set('Authorization', `Bearer ${access_token}`)
+    expect(status).toEqual(200)
+  })
+
+  test('should not get access with mock token when jwksMock is not running', async () => {
+    // Now we do not intercept queries. The queries of the middleware for the JKWS will
+    // go to the production server and the local key will be invalid.
+    const access_token = jwksMock.token({
+      aud: 'private',
+      iss: 'master',
+    })
+    const { status } = await request
+      .get('/')
+      .set('Authorization', `Bearer ${access_token}`)
+    expect(status).toEqual(401)
+  })
+})
+
+test('Another example with a non-auth0-style jkwsUri', async () => {
+  const jwksMock = createJWKSMock(
+    'https://keycloak.somedomain.com/auth/realm/application',
+    '/protocol/openid-connect/certs'
+  )
+  // We start our app.
+  const server = createApp({
+    jwksUri:
+      'https://keycloak.somedomain.com/auth/realm/application/protocol/openid-connect/certs',
+  }).listen()
+
+  const request = supertest(server)
+
+  jwksMock.start()
+  const access_token = jwksMock.token({
+    aud: 'private',
+    iss: 'master',
+  })
+  const { status } = await request
+    .get('/')
+    .set('Authorization', `Bearer ${access_token}`)
+  await tearDown({ jwksMock, server })
+  expect(status).toEqual(200)
+})
+
+const createContext = () => {
+  // This creates the local PKI
+  const jwksMock = createJWKSMock('https://hardfork.eu.auth0.com/')
+
+  // We start our app.
+  const server = createApp({
+    jwksUri: 'https://hardfork.eu.auth0.com/.well-known/jwks.json',
+  }).listen()
+
+  const request = supertest(server)
+  return {
+    jwksMock,
+    request,
+    server,
+  }
+}
+
+const tearDown = async ({ jwksMock, server }) => {
+  await server.close()
+  await jwksMock.stop()
+}

--- a/example/custom_claims.test.js
+++ b/example/custom_claims.test.js
@@ -1,114 +1,51 @@
-const createJWKSMock = require('../src/index').default
-const createApp = require('./api')
-const supertest = require('supertest')
-const { access } = require('fs')
+import { verify } from 'jsonwebtoken'
+import { pki } from 'node-forge'
+import { createKeyPair, signJwt } from './tools'
 
-describe('Some tests for authentication for our api', () => {
-  let jwksMock, server, request
-  beforeEach(() => {
-    ({ jwksMock, server, request } = createContext())
-  })
-  afterEach(async () => await tearDown({ jwksMock, server }))
+test("'Token should verify against the PKI'", async () => {
+  const keyPair = createKeyPair()
 
-  test('should not get access without correct token', async () => {
-    // We start intercepting queries (see below)
-    jwksMock.start()
-    const { status } = await request.get('/')
-    expect(status).toEqual(401)
-  })
-  test('should get access with mock token when jwksMock is running', async () => {
-    // Again we start intercepting queries
-    jwksMock.start()
-      
-    const claims = {
-      nickname: "jest.jester",
-      name: "jest@itest.com",
-      updated_at: "2022-10-09T11:36:37.582Z",
-      email: "jest@itest.com",
-      iss: "master",
-      sub: "auth0|633c191bd579670011607e98",
-      aud: "private",
-      iat: 1665315399,
-      exp: 5665351399,
-      sid: "lBZb4EUN7LpXu7Urp-lRQ3qnCzDVBf23",
-      nonce: "RzZtVlVTT1dqZ1lvWFpSYzFnbnB2RXZkdWcuNDJQRkREUH5KMUVJNWdMSA==",
-      roles: [
-        "admin",
-      ],
-      permissions: [
-        "create:all",
-        "read:all",
-        "write:all",
-        "update:all",
-        "delete:all",
-      ],
-    } 
+  // demonstrate use of claims built by actions or features which are enabled in the app/API setup in AUTH0, including:
+  // inclusion of roles and permissions
+  // use of namespaced roles
+  const claims = {
+    nickname: 'jest.jester',
+    name: 'jest@itest.com',
+    updated_at: '2022-10-09T11:36:37.582Z',
+    email: 'jest@itest.com',
+    iss: 'https://jest.au.auth0.com/',
+    sub: 'auth0|633c191bd579670011607e98',
+    aud: 'TWqR7DTIezpfW82qXFt0lchMXixIpFLQ',
+    iat: 1665315399,
+    exp: 5665351399,
+    sid: 'lBZb4EUN7LpXu7Urp-lRQ3qnCzDVBf23',
+    nonce: 'RzZtVlVTT1dqZ1lvWFpSYzFnbnB2RXZkdWcuNDJQRkREUH5KMUVJNWdMSA==',
+    'https://jest.au.auth0.com/roles': ['admin'],
+    permissions: [
+      'create:all',
+      'read:all',
+      'write:all',
+      'update:all',
+      'delete:all',
+    ],
+  } as Record<string, unknown>
 
-    const access_token = jwksMock.token(claims)
+  const token = signJwt(keyPair.privateKey, claims)
+  const decoded = verify(
+    token,
+    pki.publicKeyToPem(keyPair.publicKey)
+  ) as Record<string, unknown>
 
-    const { status } = await request
-      .get('/')
-      .set('Authorization', `Bearer ${access_token}`)
-    expect(status).toEqual(200)
-  })
+  const namespaced_roles = decoded[
+    'https://jest.au.auth0.com/roles'
+  ] as string[]
+  const permissions = decoded['permissions'] as string[]
 
-  test('should not get access with mock token when jwksMock is not running', async () => {
-    // Now we do not intercept queries. The queries of the middleware for the JKWS will
-    // go to the production server and the local key will be invalid.
-    const access_token = jwksMock.token({
-      aud: 'private',
-      iss: 'master',
-    })
-    const { status } = await request
-      .get('/')
-      .set('Authorization', `Bearer ${access_token}`)
-    expect(status).toEqual(401)
-  })
+  expect(decoded).toBeTruthy()
+
+  expect(namespaced_roles).toBeTruthy()
+  expect(namespaced_roles.indexOf('admin')).toBeGreaterThanOrEqual(0)
+
+  expect(permissions).toBeTruthy()
+  expect(permissions.indexOf('create:all')).toBeGreaterThanOrEqual(0)
 })
-
-test('Another example with a non-auth0-style jkwsUri', async () => {
-  const jwksMock = createJWKSMock(
-    'https://keycloak.somedomain.com/auth/realm/application',
-    '/protocol/openid-connect/certs'
-  )
-  // We start our app.
-  const server = createApp({
-    jwksUri:
-      'https://keycloak.somedomain.com/auth/realm/application/protocol/openid-connect/certs',
-  }).listen()
-
-  const request = supertest(server)
-
-  jwksMock.start()
-  const access_token = jwksMock.token({
-    aud: 'private',
-    iss: 'master',
-  })
-  const { status } = await request
-    .get('/')
-    .set('Authorization', `Bearer ${access_token}`)
-  await tearDown({ jwksMock, server })
-  expect(status).toEqual(200)
-})
-
-const createContext = () => {
-  // This creates the local PKI
-  const jwksMock = createJWKSMock('https://hardfork.eu.auth0.com/')
-
-  // We start our app.
-  const server = createApp({
-    jwksUri: 'https://hardfork.eu.auth0.com/.well-known/jwks.json',
-  }).listen()
-
-  const request = supertest(server)
-  return {
-    jwksMock,
-    request,
-    server,
-  }
-}
-
-const tearDown = async ({ jwksMock, server }) => {
-  await server.close()
-  await jwksMock.stop()
-}

--- a/src/jwtExtendedClaimsCreation.test.ts
+++ b/src/jwtExtendedClaimsCreation.test.ts
@@ -9,40 +9,43 @@ test("'Token should verify against the PKI'", async () => {
   // inclusion of roles and permissions
   // use of namespaced roles
   const claims = {
-    nickname: "jest.jester",
-    name: "jest@itest.com",
-    updated_at: "2022-10-09T11:36:37.582Z",
-    email: "jest@itest.com",
-    iss: "https://jest.au.auth0.com/",
-    sub: "auth0|633c191bd579670011607e98",
-    aud: "TWqR7DTIezpfW82qXFt0lchMXixIpFLQ",
+    nickname: 'jest.jester',
+    name: 'jest@itest.com',
+    updated_at: '2022-10-09T11:36:37.582Z',
+    email: 'jest@itest.com',
+    iss: 'https://jest.au.auth0.com/',
+    sub: 'auth0|633c191bd579670011607e98',
+    aud: 'TWqR7DTIezpfW82qXFt0lchMXixIpFLQ',
     iat: 1665315399,
     exp: 5665351399,
-    sid: "lBZb4EUN7LpXu7Urp-lRQ3qnCzDVBf23",
-    nonce: "RzZtVlVTT1dqZ1lvWFpSYzFnbnB2RXZkdWcuNDJQRkREUH5KMUVJNWdMSA==",
-    "https://jest.au.auth0.com/roles": [
-      "admin",
-    ],
+    sid: 'lBZb4EUN7LpXu7Urp-lRQ3qnCzDVBf23',
+    nonce: 'RzZtVlVTT1dqZ1lvWFpSYzFnbnB2RXZkdWcuNDJQRkREUH5KMUVJNWdMSA==',
+    'https://jest.au.auth0.com/roles': ['admin'],
     permissions: [
-      "create:all",
-      "read:all",
-      "write:all",
-      "update:all",
-      "delete:all",
+      'create:all',
+      'read:all',
+      'write:all',
+      'update:all',
+      'delete:all',
     ],
   } as Record<string, unknown>
 
   const token = signJwt(keyPair.privateKey, claims)
-  const decoded = verify(token, pki.publicKeyToPem(keyPair.publicKey)) as Record<string, unknown>
-  
-  const namespaced_roles = decoded["https://jest.au.auth0.com/roles"] as string[]
-  const permissions = decoded["permissions"] as string[]
-  
+  const decoded = verify(
+    token,
+    pki.publicKeyToPem(keyPair.publicKey)
+  ) as Record<string, unknown>
+
+  const namespaced_roles = decoded[
+    'https://jest.au.auth0.com/roles'
+  ] as string[]
+  const permissions = decoded['permissions'] as string[]
+
   expect(decoded).toBeTruthy()
-  
+
   expect(namespaced_roles).toBeTruthy()
-  expect(namespaced_roles.indexOf("admin")).toBeGreaterThanOrEqual(0)
+  expect(namespaced_roles.indexOf('admin')).toBeGreaterThanOrEqual(0)
 
   expect(permissions).toBeTruthy()
-  expect(permissions.indexOf("create:all")).toBeGreaterThanOrEqual(0)
+  expect(permissions.indexOf('create:all')).toBeGreaterThanOrEqual(0)
 })

--- a/src/jwtExtendedClaimsCreation.test.ts
+++ b/src/jwtExtendedClaimsCreation.test.ts
@@ -1,0 +1,48 @@
+import { verify } from 'jsonwebtoken'
+import { pki } from 'node-forge'
+import { createKeyPair, signJwt } from './tools'
+
+test("'Token should verify against the PKI'", async () => {
+  const keyPair = createKeyPair()
+
+  // demonstrate use of claims built by actions or features which are enabled in the app/API setup in AUTH0, including:
+  // inclusion of roles and permissions
+  // use of namespaced roles
+  const claims = {
+    nickname: "jest.jester",
+    name: "jest@itest.com",
+    updated_at: "2022-10-09T11:36:37.582Z",
+    email: "jest@itest.com",
+    iss: "https://jest.au.auth0.com/",
+    sub: "auth0|633c191bd579670011607e98",
+    aud: "TWqR7DTIezpfW82qXFt0lchMXixIpFLQ",
+    iat: 1665315399,
+    exp: 5665351399,
+    sid: "lBZb4EUN7LpXu7Urp-lRQ3qnCzDVBf23",
+    nonce: "RzZtVlVTT1dqZ1lvWFpSYzFnbnB2RXZkdWcuNDJQRkREUH5KMUVJNWdMSA==",
+    "https://jest.au.auth0.com/roles": [
+      "admin",
+    ],
+    permissions: [
+      "create:all",
+      "read:all",
+      "write:all",
+      "update:all",
+      "delete:all",
+    ],
+  } as Record<string, unknown>
+
+  const token = signJwt(keyPair.privateKey, claims)
+  const decoded = verify(token, pki.publicKeyToPem(keyPair.publicKey)) as Record<string, unknown>
+  
+  const namespaced_roles = decoded["https://jest.au.auth0.com/roles"] as string[]
+  const permissions = decoded["permissions"] as string[]
+  
+  expect(decoded).toBeTruthy()
+  
+  expect(namespaced_roles).toBeTruthy()
+  expect(namespaced_roles.indexOf("admin")).toBeGreaterThanOrEqual(0)
+
+  expect(permissions).toBeTruthy()
+  expect(permissions.indexOf("create:all")).toBeGreaterThanOrEqual(0)
+})


### PR DESCRIPTION
This PR provides additional tests which mirror the style of test code in the same folder, and demonstrate the use of more complex claims structures, including namespaced roles.

The intention is to demonstrate to the audience that more complex claim structures function perfectly well.