### PR TITLE
fix: disallow using numbers for "iat" and "exp"

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "@types/tape": "^4.13.2",
     "@typescript-eslint/eslint-plugin": "^5.40.0",
     "@typescript-eslint/parser": "^5.40.0",
-    "eslint": "^8.25.0",
+    "eslint": "^8.22.0",
     "eslint-config-prettier": "^8.5.0",
     "husky": "^8.0.1",
     "jest": "^29.2.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,16 +1,11 @@
+import { JwtPayload } from 'jsonwebtoken'
 import nock from 'nock'
 import { createJWKS, createKeyPair, signJwt } from './tools'
-export interface JWKSMock {
-  start(): void
-  stop(): void
-  kid(): string
-  token(token: Record<string, unknown>): string
-}
 
 const createJWKSMock = (
   jwksOrigin: string,
   jwksPath = '/.well-known/jwks.json'
-): JWKSMock => {
+) => {
   const keypair = createKeyPair()
   const JWKS = createJWKS({
     ...keypair,
@@ -30,9 +25,8 @@ const createJWKSMock = (
     }
   }
 
-  const token = (token = {}) => {
-    return signJwt(keypair.privateKey, token, kid())
-  }
+  const token = (token: JwtPayload = {}) =>
+    signJwt(keypair.privateKey, token, kid())
 
   return {
     start,

--- a/src/jwksRsa.test.ts
+++ b/src/jwksRsa.test.ts
@@ -24,4 +24,21 @@ describe('Tests for JWKS being correctly consumed by jwks-rsa client', () => {
     )
     expect(verify(auth0Mock.token({}), signingKey)).toBeTruthy()
   })
+  test('iat and exp are numbers', async () => {
+    const key = await pify(client.getSigningKey)(auth0Mock.kid())
+    const signingKey = String(
+      (key as CertSigningKey).publicKey || (key as RsaSigningKey).rsaPublicKey
+    )
+    expect(() =>
+      // @ts-expect-error types should prevent using a string for iat
+      verify(auth0Mock.token({ iat: '123' }), signingKey)
+    ).toThrowError('iat')
+    expect(() =>
+      // @ts-expect-error types should prevent using a string for exp
+      verify(auth0Mock.token({ exp: '123' }), signingKey)
+    ).toThrowError('exp')
+    expect(() =>
+      verify(auth0Mock.token({ iat: 123, exp: 64779973980000 }), signingKey)
+    ).not.toThrow()
+  })
 })

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -1,6 +1,6 @@
 import * as base64url from 'base64-url'
 import { createHash } from 'crypto'
-import { sign } from 'jsonwebtoken'
+import { sign, JwtPayload } from 'jsonwebtoken'
 import * as forge from 'node-forge'
 import NodeRSA from 'node-rsa'
 
@@ -144,26 +144,14 @@ export const createKeyPair = () => {
   }
 }
 
-export interface JwtPayload {
-  sub?: string
-  iss?: string
-  aud?: string
-  exp?: string
-  nbf?: string
-  iat?: string
-  jti?: string
-}
-
 export const signJwt = (
   privateKey: forge.pki.PrivateKey,
   jwtPayload: JwtPayload,
   kid?: string
-) => {
-  const bufferedJwt = Buffer.from(JSON.stringify(jwtPayload))
-  return sign(bufferedJwt, forge.pki.privateKeyToPem(privateKey), {
+) =>
+  sign(jwtPayload, forge.pki.privateKeyToPem(privateKey), {
     header: { kid, alg: 'RS256' },
   })
-}
 
 // Below taken from https://coolaj86.com/articles/bigints-and-base64-in-javascript/
 // Binary string to ASCII (base64)

--- a/yarn.lock
+++ b/yarn.lock
@@ -5206,7 +5206,7 @@ __metadata:
     "@typescript-eslint/eslint-plugin": ^5.40.0
     "@typescript-eslint/parser": ^5.40.0
     base64-url: ^2.3.3
-    eslint: ^8.25.0
+    eslint: ^8.22.0
     eslint-config-prettier: ^8.5.0
     husky: ^8.0.1
     jest: ^29.2.0


### PR DESCRIPTION
fix #79