### PR TITLE
feat: make createJWKS more robust on malformed base strings

### DIFF
--- a/example/authentication.test.js
+++ b/example/authentication.test.js
@@ -44,8 +44,8 @@ describe('Some tests for authentication for our api', () => {
 })
 test('Another example with a non-auth0-style jkwsUri', async () => {
   const jwksMock = createJWKSMock(
-    'https://keycloak.somedomain.com/auth/realm/application',
-    '/protocol/openid-connect/certs'
+    'https://keycloak.somedomain.com',
+    '/auth/realm/application/protocol/openid-connect/certs'
   )
   // We start our app.
   const server = createApp({

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,17 +4,16 @@ import { setupServer } from 'msw/node'
 import { rest } from 'msw'
 
 const createJWKSMock = (
-  jwksOrigin: string,
+  jwksBase: string,
   jwksPath = '/.well-known/jwks.json'
 ) => {
   const keypair = createKeyPair()
   const JWKS = createJWKS({
     ...keypair,
-    jwksOrigin,
+    jwksOrigin: jwksBase,
   })
-
   const server = setupServer(
-    rest.get(`${jwksOrigin}${jwksPath}`, (_, res, ctx) =>
+    rest.get(new URL(jwksPath, jwksBase).href, (_, res, ctx) =>
       res(ctx.status(200), ctx.json(JWKS))
     )
   )


### PR DESCRIPTION
this is a breaking change, since now one can only provide a hostname and protocol as the first parameter to `createJWKS`. However 3.0.0 was just released and I think nobody will notice.